### PR TITLE
hector_camera_control: include header builtin_double.h (fix #1)

### DIFF
--- a/hector_camera_joint_controller/src/cam_joint_trajectory_controller.cpp
+++ b/hector_camera_joint_controller/src/cam_joint_trajectory_controller.cpp
@@ -31,6 +31,7 @@
 #include <control_msgs/FollowJointTrajectoryAction.h>
 #include <angles/angles.h>
 #include <std_msgs/Float64.h>
+#include <std_msgs/builtin_double.h>
 
 namespace cam_control {
 


### PR DESCRIPTION
Fix for #1 (untested):

In order to publish built-in types directly as the corresponding std_msgs message, like in [cam_joint_trajectory_controller.cpp:365](https://github.com/tu-darmstadt-ros-pkg/hector_camera_control/blob/0fd7793068b19eb688f07617f65bba6d2667154f/hector_camera_joint_controller/src/cam_joint_trajectory_controller.cpp#L365), we need to include the `std_msgs/builtin_double.h` header which defines the necessary message traits.
