### PR TITLE
Moveit collision checks orientation mode

### DIFF
--- a/hector_camera_joint_controller/include/hector_camera_joint_controller/cam_joint_trajectory_controller.h
+++ b/hector_camera_joint_controller/include/hector_camera_joint_controller/cam_joint_trajectory_controller.h
@@ -171,6 +171,7 @@ private:
   bool use_direct_position_commands_;
   bool use_planning_based_pointing_;
   bool disable_orientation_camera_command_input_;
+  bool use_collision_checks_in_orientation_mode_;
 };
 
 }

--- a/hector_camera_joint_controller/include/hector_camera_joint_controller/cam_joint_trajectory_controller.h
+++ b/hector_camera_joint_controller/include/hector_camera_joint_controller/cam_joint_trajectory_controller.h
@@ -54,6 +54,7 @@
 
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <moveit/robot_state/robot_state.h>
+#include <moveit/planning_scene_monitor/current_state_monitor.h>
 
 namespace cam_control
 {
@@ -139,6 +140,7 @@ private:
   robot_model::RobotModelPtr moveit_robot_model_;
   robot_state::RobotStatePtr moveit_robot_state_;
   std::vector<std::string> joint_names_;
+  ros::ServiceClient get_planning_scene_;
 
   geometry_msgs::QuaternionStamped::ConstPtr latest_orientation_cmd_;
   Eigen::Quaterniond rotation_;

--- a/hector_camera_joint_controller/launch/hector_pan_tilt_sensor_head_jasmine2018.launch
+++ b/hector_camera_joint_controller/launch/hector_pan_tilt_sensor_head_jasmine2018.launch
@@ -18,6 +18,7 @@
     <param name="stabilize_default_direction_reference" value="false" />
 
     <param name="joint_order_type" value="zyx" />
-    <param name="use_planning_based_pointing" value="true" />    
+    <param name="use_planning_based_pointing" value="true" />
+    <param name="use_collision_checks_in_orientation_mode" value="true" />
   </node>
 </launch>

--- a/hector_camera_joint_controller/src/cam_joint_trajectory_controller.cpp
+++ b/hector_camera_joint_controller/src/cam_joint_trajectory_controller.cpp
@@ -504,6 +504,8 @@ void CamJointTrajControl::ComputeAndSendJointCommand(const geometry_msgs::Quater
 
     //Test if pose leads to self collisions -
     planning_scene::PlanningScene planning_scene(moveit_robot_model_);
+    // ignore collision between these links, only padding collides and because of this camera cannot look upwards
+    planning_scene.getAllowedCollisionMatrixNonConst().setEntry("sensor_head_thermal_cam_frame","chassis_link",true);
     moveit_msgs::GetPlanningScene srv;
     srv.request.components.components = srv.request.components.ROBOT_STATE;
     if (this->get_planning_scene_.call(srv))
@@ -515,10 +517,9 @@ void CamJointTrajControl::ComputeAndSendJointCommand(const geometry_msgs::Quater
     collision_detection::CollisionRequest collision_request;
     collision_detection::CollisionResult collision_result;
     collision_request.contacts = false;// true; //activate for debugging
-    collision_request.max_contacts = 1000;
+    collision_request.max_contacts = 100;
     planning_scene.checkSelfCollision(collision_request, collision_result);
     bool current_state_colliding = collision_result.collision;
-
     //ROS_INFO_STREAM("Current state is " << (collision_result.collision ? "in" : "not in") << " self collision");
     if(!collision_result.collision)
     {
@@ -535,7 +536,7 @@ void CamJointTrajControl::ComputeAndSendJointCommand(const geometry_msgs::Quater
       collision_detection::CollisionResult::ContactMap::const_iterator it;
       //for (it = collision_result.contacts.begin(); it != collision_result.contacts.end(); ++it)
       //{
-      //  ROS_INFO("Contact between: %s and %s", it->first.first.c_str(), it->first.second.c_str());
+       // ROS_INFO("Contact between: %s and %s", it->first.first.c_str(), it->first.second.c_str());
       //}
     }
     if (!collision_result.collision or current_state_colliding)


### PR DESCRIPTION
Implemented collision checks for the camera joint controller. Prevents collisions on asterix between the arm and the sensor head.