### PR TITLE
Read joint limits from the URDF instead of config file

### DIFF
--- a/hector_camera_joint_controller/CMakeLists.txt
+++ b/hector_camera_joint_controller/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(catkin REQUIRED COMPONENTS
   moveit_ros_planning
   tf_conversions
   kdl_parser
+  urdf
 )
 
 find_package(Eigen3 REQUIRED)

--- a/hector_camera_joint_controller/include/hector_camera_joint_controller/cam_joint_trajectory_controller.h
+++ b/hector_camera_joint_controller/include/hector_camera_joint_controller/cam_joint_trajectory_controller.h
@@ -56,6 +56,7 @@
 
 #include <moveit/robot_model_loader/robot_model_loader.h>
 #include <moveit/robot_state/robot_state.h>
+#include <urdf/model.h>
 
 namespace cam_control
 {
@@ -95,6 +96,7 @@ public:
 
 class TrackedJointManager{
 public:
+  TrackedJointManager();
   void addJoint(const std::string& ns, ros::NodeHandle& nh);
   void addJoint(const TrackedJoint& joint);
   void updateState(const sensor_msgs::JointState& msg);
@@ -104,6 +106,7 @@ public:
   size_t getNumJoints() { return tracked_joints_.size(); };
 
   std::vector<TrackedJoint> tracked_joints_;
+  urdf::Model model_;
 };
 
 class CamJointTrajControl

--- a/hector_camera_joint_controller/package.xml
+++ b/hector_camera_joint_controller/package.xml
@@ -25,6 +25,7 @@
   <depend>libceres-dev</depend>
   <depend>liborocos-kdl</depend>
   <depend>kdl_parser</depend>
+  <depend>urdf</depend>
 
   <export>
   </export>

--- a/hector_camera_joint_controller/src/cam_joint_trajectory_controller.cpp
+++ b/hector_camera_joint_controller/src/cam_joint_trajectory_controller.cpp
@@ -63,6 +63,11 @@ double normalize_angle(double x)
   }
 }
 
+TrackedJointManager::TrackedJointManager()
+{
+  model_.initParam("/robot_description");
+}
+
 TrackedJoint::TrackedJoint(const std::string& joint_name,
              const std::string& topic,
              const double lower_limit,
@@ -138,18 +143,12 @@ void TrackedJointManager::addJoint(const std::string& ns, ros::NodeHandle& nh)
   double max_val;
   double reached_threshold;
   nh.getParam(ns + "/name", joint_name);
-  nh.getParam(ns +"/topic", topic);
-  nh.param(ns +"/limit_lower", min_val, -M_PI);
-  nh.param(ns +"/limit_upper", max_val, M_PI);
+  nh.getParam(ns + "/topic", topic);
   nh.param(ns +"/reached_threshold", reached_threshold, 0.05);
 
-  this->addJoint(TrackedJoint(joint_name,
-                              topic,
-                              min_val,
-                              max_val,
-                              reached_threshold,
-                              nh));
+  auto joint_limits = model_.getJoint(joint_name)->limits;
 
+  this->addJoint(TrackedJoint(joint_name, topic, joint_limits->lower, joint_limits->upper, reached_threshold, nh));
 }
 
 void TrackedJointManager::addJoint(const TrackedJoint& joint)


### PR DESCRIPTION
To reduce redundancies, read the joint limits already specified in the URDF instead of duplicating them in a config file