### PR TITLE
Support teleoperation of multi-DoF cameras + simplify velocity commands

### DIFF
--- a/hector_camera_joint_controller/CMakeLists.txt
+++ b/hector_camera_joint_controller/CMakeLists.txt
@@ -2,18 +2,19 @@ cmake_minimum_required(VERSION 2.8.3)
 project(hector_camera_joint_controller)
 
 find_package(catkin REQUIRED COMPONENTS
+  actionlib
+  cmake_modules
   control_msgs
   geometry_msgs
+  hector_perception_msgs
+  kdl_parser
+  moveit_core
+  moveit_msgs
+  moveit_ros_planning
+  robotnik_msgs
   roscpp
   tf
-  cmake_modules
-  actionlib
-  moveit_msgs
-  hector_perception_msgs
-  moveit_core
-  moveit_ros_planning
   tf_conversions
-  kdl_parser
   urdf
 )
 

--- a/hector_camera_joint_controller/include/hector_camera_joint_controller/cam_joint_trajectory_controller.h
+++ b/hector_camera_joint_controller/include/hector_camera_joint_controller/cam_joint_trajectory_controller.h
@@ -51,6 +51,7 @@
 
 #include <control_msgs/FollowJointTrajectoryAction.h>
 #include <control_msgs/JointControllerState.h>
+#include <robotnik_msgs/ptz.h>
 
 #include <hector_perception_msgs/LookAtAction.h>
 
@@ -150,6 +151,9 @@ private:
   bool findPattern(const std::string& pattern_name);
 
   void cmdCallback(const geometry_msgs::QuaternionStamped::ConstPtr& cmd_msg);
+  void panTiltVelocityCallback(const robotnik_msgs::ptz::ConstPtr& msg);
+
+  void getJointValuesForPose(const std::string pose_name, std::map<std::string, double>& group_joint_values);
 
   double getClosestPointLineSegment(const Eigen::Vector3d& head,
                                     const Eigen::Vector3d& tail,
@@ -186,6 +190,8 @@ private:
 
   ros::Subscriber joint_state_sub_;
   ros::Subscriber sub_;
+  ros::Subscriber pan_tilt_sub_;
+
   tf::TransformListener* transform_listener_;
 
   ros::Publisher pattern_info_pub_;
@@ -203,6 +209,7 @@ private:
 
   KDL::Tree tree_;
 
+  std::vector<double> previous_computation_;
   geometry_msgs::QuaternionStamped::ConstPtr latest_orientation_cmd_;
   Eigen::Quaterniond rotation_;
 

--- a/hector_camera_joint_controller/include/hector_camera_joint_controller/cam_joint_trajectory_controller.h
+++ b/hector_camera_joint_controller/include/hector_camera_joint_controller/cam_joint_trajectory_controller.h
@@ -243,7 +243,7 @@ private:
   bool has_elevating_mast_;
   
   bool use_planning_based_pointing_;
-  bool disable_orientation_camera_command_input_;
+  bool enable_velocity_control_;
 };
 
 }

--- a/hector_camera_joint_controller/package.xml
+++ b/hector_camera_joint_controller/package.xml
@@ -26,6 +26,7 @@
   <depend>liborocos-kdl</depend>
   <depend>kdl_parser</depend>
   <depend>urdf</depend>
+  <depend>robotnik_msgs</depend>
 
   <export>
   </export>

--- a/hector_camera_joint_controller/src/cam_joint_trajectory_controller.cpp
+++ b/hector_camera_joint_controller/src/cam_joint_trajectory_controller.cpp
@@ -503,13 +503,13 @@ void CamJointTrajControl::getJointValuesForPose(std::string pose_name,
 // Reset
 void CamJointTrajControl::Reset()
 {
+  int n = joint_manager_.getNumJoints();
+  double joint_values[n];
+
   if (!use_direct_position_commands_)
   {
     std::map<std::string, double> group_joint_values;
     getJointValuesForPose("transport", group_joint_values);
-
-    int n = joint_manager_.getNumJoints();
-    double joint_values[n];
 
     for (int i = 0; i < n; i++)
     {
@@ -520,8 +520,8 @@ void CamJointTrajControl::Reset()
   }
   else
   {
-    // Reset orientation
-    latest_orientation_cmd_.reset();
+    std::fill(joint_values, joint_values + n, 0.0);
+    SendJointCommand(joint_values);
   }
 }
 
@@ -904,7 +904,14 @@ void CamJointTrajControl::panTiltVelocityCallback(const robotnik_msgs::ptz::Cons
     }
   }
 
-  this->SendTrajectoryCommand(joint_values);
+  if (use_direct_position_commands_)
+  {
+    this->SendJointCommand(joint_values);
+  }
+  else
+  {
+    this->SendTrajectoryCommand(joint_values);
+  }
 }
 
 // NEW: Store the velocities from the ROS message

--- a/hector_camera_joint_controller/src/cam_joint_trajectory_controller.cpp
+++ b/hector_camera_joint_controller/src/cam_joint_trajectory_controller.cpp
@@ -390,9 +390,14 @@ void CamJointTrajControl::Init()
   control_timer = nh_.createTimer(ros::Duration(control_loop_period_), &CamJointTrajControl::controlTimerCallback, this, false, true);
   
   pnh_.getParam("disable_orientation_camera_command_input", disable_orientation_camera_command_input_);
-  
-  if (!disable_orientation_camera_command_input_){
-    sub_ = nh_.subscribe("/camera/command", 1, &CamJointTrajControl::cmdCallback, this);    
+
+  if (!disable_orientation_camera_command_input_)  // Use quaternion as orientation input
+  {
+    sub_ = nh_.subscribe("/camera/command", 1, &CamJointTrajControl::cmdCallback, this);
+  }
+  else  // Use relative movement as input
+  {
+    pan_tilt_sub_ = nh_.subscribe("/pan_tilt_vel", 1, &CamJointTrajControl::panTiltVelocityCallback, this);
   }
 
   this->Reset();
@@ -411,21 +416,17 @@ void CamJointTrajControl::getJointNamesFromMoveGroup()
   // Load moveit robot model to retrieve joint names
   robot_model_loader::RobotModelLoader robot_model_loader("robot_description", false);
   moveit_robot_model_ = robot_model_loader.getModel();
+
   if (!moveit_robot_model_){
     ROS_FATAL_STREAM("Could not load robot model. Exiting.");
     exit(0);
   }
-  moveit_robot_state_ = std::make_shared<robot_state::RobotState>(moveit_robot_model_);
-  const robot_state::JointModelGroup* group = moveit_robot_state_->getJointModelGroup(move_group_name_);
-  if (!group) {
-    ROS_FATAL_STREAM("Could not find move group with name '" << move_group_name_ << "'. Exiting.");
-    exit(0);
-  }
-  joint_names_ = group->getJointModelNames();
-  std::map<std::string, double> group_joint_values;
-  group->getVariableDefaultPositions(lookout_pose_name_, group_joint_values);
 
-  for (unsigned int i = 0; i < joint_names_.size(); ++i){
+  std::map<std::string, double> group_joint_values;
+  this->getJointValuesForPose(lookout_pose_name_, group_joint_values);
+
+  for (unsigned int i = 0; i < joint_names_.size(); ++i)
+  {
     ROS_INFO("[cam joint ctrl] Joint %d : %s", static_cast<int>(i), joint_names_[i].c_str());
 
     if (joint_manager_.getJoint(i).keep_fixed_)
@@ -484,11 +485,44 @@ void CamJointTrajControl::getJointNamesFromController(ros::NodeHandle& nh)
   }while (!retrieved_names);
 }
 
+void CamJointTrajControl::getJointValuesForPose(std::string pose_name,
+                                                std::map<std::string, double>& group_joint_values)
+{
+  moveit_robot_state_ = std::make_shared<robot_state::RobotState>(moveit_robot_model_);
+  const robot_state::JointModelGroup* group = moveit_robot_state_->getJointModelGroup(move_group_name_);
+  if (!group)
+  {
+    ROS_FATAL_STREAM("Could not find move group with name '" << move_group_name_ << "'. Exiting.");
+    exit(0);
+  }
+  joint_names_ = group->getJointModelNames();
+
+  group->getVariableDefaultPositions(pose_name, group_joint_values);
+}
+
 // Reset
 void CamJointTrajControl::Reset()
 {
-  // Reset orientation
-  latest_orientation_cmd_.reset();
+  if (!use_direct_position_commands_)
+  {
+    std::map<std::string, double> group_joint_values;
+    getJointValuesForPose("transport", group_joint_values);
+
+    int n = joint_manager_.getNumJoints();
+    double joint_values[n];
+
+    for (int i = 0; i < n; i++)
+    {
+      joint_values[i] = group_joint_values[joint_manager_.getJoint(i).state_.name[0]];
+    }
+
+    SendTrajectoryCommand(joint_values);
+  }
+  else
+  {
+    // Reset orientation
+    latest_orientation_cmd_.reset();
+  }
 }
 
 bool CamJointTrajControl::planAndMoveToPoint(const geometry_msgs::PointStamped& point, double velocity_scaling_factor)
@@ -637,14 +671,7 @@ bool CamJointTrajControl::SendTrajectoryCommand(const double* joint_values)
   for (size_t i = 0; i < joint_names_.size(); ++i)
   {
     joint_constraint.joint_name = joint_names_[i];
-    if (joint_manager_.getJoint(i).keep_fixed_)
-    {
-      joint_constraint.position = joint_manager_.getJoint(i).fixed_value_;
-    }
-    else
-    {
-      joint_constraint.position = joint_values[i];
-    }
+    joint_constraint.position = joint_values[i];
 
     constraints.joint_constraints.push_back(joint_constraint);
   }
@@ -851,6 +878,35 @@ bool CamJointTrajControl::ComputeHeightForPoint(const geometry_msgs::PointStampe
   */
 }
 
+void CamJointTrajControl::panTiltVelocityCallback(const robotnik_msgs::ptz::ConstPtr& msg)
+{
+  if (!msg->relative)
+  {
+    Reset();
+    return;
+  }
+
+  int n = joint_manager_.getNumJoints();
+  double joint_values[n];
+
+  float offset = msg->pan;  // Assumes pan-tilt order
+
+  for (int i = 0; i < n; i++)
+  {
+    if (joint_manager_.getJoint(i).keep_fixed_)
+    {
+      joint_values[i] = joint_manager_.getJoint(i).fixed_value_;
+    }
+    else
+    {
+      joint_values[i] = joint_manager_.getJoint(i).state_.position[0] + offset;
+      offset = msg->tilt;
+    }
+  }
+
+  this->SendTrajectoryCommand(joint_values);
+}
+
 // NEW: Store the velocities from the ROS message
 void CamJointTrajControl::cmdCallback(const geometry_msgs::QuaternionStamped::ConstPtr& cmd_msg)
 {
@@ -1055,22 +1111,16 @@ bool CamJointTrajControl::aimAtPOI(const geometry_msgs::PointStamped& poi_positi
   geometry_msgs::QuaternionStamped command_quat;
   Eigen::Vector3d pre_angles;
 
-  if (this->ComputeDirectionForPoint(poi_position, command_quat))
-  {
-    this->ComputeJointCommand(command_quat, pre_angles);
-  }
-
-  ROS_DEBUG("Precomputed pan angle: %f", pre_angles(0));
-  ROS_DEBUG("Precomputed tilt angle: %f", pre_angles(1));
-
   // The variable to solve for with its initial precomputed value respecting joint limits
   const int n = joint_manager_.getNumJoints();
   double desired_angles[n];
 
-  for (int i = 0; i < 2; i++)
+  if (previous_computation_.size() == n)
   {
-    desired_angles[i] = std::max(std::min(pre_angles(i), joint_manager_.getJoint(i).upper_limit_),
-                                 joint_manager_.getJoint(i).lower_limit_);
+    for (int i = 0; i < n; i++)
+    {
+      desired_angles[i] = previous_computation_[i];
+    }
   }
 
   KDL::Chain chain;
@@ -1176,6 +1226,8 @@ bool CamJointTrajControl::aimAtPOI(const geometry_msgs::PointStamped& poi_positi
   ROS_DEBUG("Computed pan angle : %f", best_result[0]);
   ROS_DEBUG("Computed residual: %f", best_residual);
 
+  previous_computation_.clear();
+
   // TODO: Check deviation to goal here, potentially abort
 
   if (use_direct_position_commands_)
@@ -1184,6 +1236,14 @@ bool CamJointTrajControl::aimAtPOI(const geometry_msgs::PointStamped& poi_positi
   }
   else
   {
+    for (size_t i = 0; i < joint_names_.size(); ++i)
+    {
+      if (joint_manager_.getJoint(i).keep_fixed_)
+      {
+        best_result[i] = joint_manager_.getJoint(i).fixed_value_;
+      }
+      previous_computation_.push_back(best_result[i]);
+    }
     SendTrajectoryCommand(best_result);
   }
 

--- a/hector_camera_joint_controller/src/cam_joint_trajectory_controller.cpp
+++ b/hector_camera_joint_controller/src/cam_joint_trajectory_controller.cpp
@@ -882,6 +882,11 @@ void CamJointTrajControl::panTiltVelocityCallback(const robotnik_msgs::ptz::Cons
     return;
   }
 
+  if (msg->pan == 0.0 && msg->tilt == 0.0)
+  {
+    return;
+  }
+
   int n = joint_manager_.getNumJoints();
   double joint_values[n];
 

--- a/hector_camera_joint_controller/src/cam_joint_trajectory_controller.cpp
+++ b/hector_camera_joint_controller/src/cam_joint_trajectory_controller.cpp
@@ -664,10 +664,11 @@ bool CamJointTrajControl::SendTrajectoryCommand(const double* joint_values)
   joint_constraint.tolerance_above = 0.001;
   joint_constraint.tolerance_below = 0.001;
 
-  for (size_t i = 0; i < joint_names_.size(); ++i)
+  for (size_t i = 0; i < joint_manager_.getNumJoints(); ++i)
   {
-    joint_constraint.joint_name = joint_names_[i];
+    joint_constraint.joint_name = joint_manager_.getJoint(i).state_.name[0];
     joint_constraint.position = joint_values[i];
+    joint_manager_.getJoint(i).desired_pos_ = joint_values[i];
 
     constraints.joint_constraints.push_back(joint_constraint);
   }
@@ -900,7 +901,16 @@ void CamJointTrajControl::panTiltVelocityCallback(const robotnik_msgs::ptz::Cons
     }
     else
     {
-      joint_values[i] = joint_manager_.getJoint(i).state_.position[0] + offset;
+      if (std::abs(joint_manager_.getJoint(i).state_.position[0] - joint_manager_.getJoint(i).desired_pos_) <
+          2 * std::abs(offset))
+      {
+        joint_values[i] = joint_manager_.getJoint(i).desired_pos_ + offset;
+      }
+      else
+      {
+        joint_values[i] = joint_manager_.getJoint(i).state_.position[0] + offset;
+      }
+
       offset = msg->tilt;
     }
   }


### PR DESCRIPTION
- Velocity commands for moving the camera are sent via a [single message](https://docs.ros.org/en/indigo/api/robotnik_msgs/html/msg/ptz.html).
- Convert velocity commands to position commands and send them using either a JointPositionController or a JointTrajectoryController. Predefined joints are kept in a fixed position.
- Remoded how the camera is being reset.